### PR TITLE
Changes for fixing Chromecast Blue icon on TV problem

### DIFF
--- a/src/local/ChromecastSkill.py
+++ b/src/local/ChromecastSkill.py
@@ -41,7 +41,7 @@ class Skill():
         print('Volume command sent to Chromecast. Set to {}.'.format(volume_normalized))
 
     def play_video(self, data, cast, mc):
-        url = subprocess.check_output("youtube-dl -g --no-check-certificate -- " + data['videoId'], shell=True)
+        url = subprocess.check_output("youtube-dl -g --no-check-certificate -f best -- " + data['videoId'], shell=True)
         mc.play_media(url, 'video/mp4')
         print('video sent to chromecast: {}'.format(url))
 

--- a/src/local/requirements.txt
+++ b/src/local/requirements.txt
@@ -1,6 +1,6 @@
-boto3==1.4.3
-miniupnpc==1.9
-PyChromecast==0.8.1
-requests==2.18.1
+boto3==1.4.7
+miniupnpc==2.0.2
+PyChromecast==0.8.2
+requests==2.18.4
 zeroconf==0.19.1
-youtube-dl==2017.1.25
+youtube-dl==2017.8.27.1


### PR DESCRIPTION
YouTube-dl was spitting two urls. One for Audio and other for Video. This was causing issue on casting on chromecast. Chromecast was only showing blue icon. I also updated the requirement file with newest versions of packages i have tried locally.